### PR TITLE
README.md: fix wording; lossless to lossy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ the light reflects off of the sample rather than transmitting through
 it.
 
 My original photo was too large for Github, so the version that you
-will work with is reduced in resolution.  Lossless compression is
+will work with is reduced in resolution.  Lossy compression is
 avoided because it can confuse the image recognition.
 
 If you produce your own photo of the DMG-01-CPU chip, the instructions


### PR DESCRIPTION
lossless is png, tiff, even bmp (RLE)
lossy is like jpeg
I believe the point is that lossy compression artifacts like JPEG produces could interfere with image recognition.